### PR TITLE
Added missing dependency (chalk)

### DIFF
--- a/modules/oxide/tasks/demos.js
+++ b/modules/oxide/tasks/demos.js
@@ -3,6 +3,7 @@ const path = require('path');
 const connect = require('connect');
 const liveReload = require('connect-livereload');
 const serveStatic = require('serve-static');
+const chalk = require("chalk");
 
 module.exports = function (grunt) {
   grunt.registerTask('buildDemos', function() {


### PR DESCRIPTION
Tried to run the create skin tutorial (https://www.tiny.cloud/docs/tinymce/latest/creating-a-skin/) and a few steps are not working because chalk is not imported.

Related Ticket: 

Description of Changes:
* Added chalk to demos.js

Pre-checks:
* [ ] Changelog entry added
* [ ] Tests have been added (if applicable)
* [ ] Branch prefixed with `feature/`, `hotfix/` or `spike/`

Review:
* [ ] Milestone set
* [ ] Docs ticket created (if applicable)

GitHub issues (if applicable):
